### PR TITLE
Fix a NULL dereference when trying to delete a non-existing item

### DIFF
--- a/dict.c
+++ b/dict.c
@@ -135,6 +135,9 @@ boolean checkword(Trie t, char *s) {
 void delword(Trie t, char *s) {
 	if (s[0] != '\0') {
 		int index = convertToIndex(s[0]);//index sets the path for recursion to go
+        if (t->next[index] == NULL) {
+            return;
+        }
 		//through since it is properly mapped to from s[0], this will ensure that
 		//only the correct sequence of trie nodes (based on the characters of s) 
 		//will be travelled to.


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).